### PR TITLE
Update path to std@0.67.0

### DIFF
--- a/src/deps.js
+++ b/src/deps.js
@@ -1,4 +1,4 @@
-export * as path from "https://deno.land/std@0.61.0/path/mod.ts";
+export * as path from "https://deno.land/std@0.67.0/path/mod.ts";
 
 export * as asap from "https://cdn.pika.dev/asap/^2.0.6";
 


### PR DESCRIPTION
Upgrades from `std@0.61.0` to `std@0.67.0` to support the newest versions of Deno.